### PR TITLE
Update Google Classroom link and join code across site

### DIFF
--- a/Yr-10-Mirror-main/index.html
+++ b/Yr-10-Mirror-main/index.html
@@ -28,8 +28,8 @@
 <img alt="Mirror Project" src="Mirror%20Picture.png" style="max-width:300px;width:100%;border-radius:5px;"/>
 </div>
 <p>Use the code below to join the class and access all online resources:</p>
-<p><strong>Classroom Code: <span style="color: #d9534f; font-size: 1.3em;">l3uugkr</span></strong></p>
-<a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" target="_blank">Join Google Classroom</a>
+<p><strong>Classroom Code: <span style="color: #d9534f; font-size: 1.3em;">i44pfqp6</span></strong></p>
+<a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" target="_blank">Join Google Classroom</a>
 </section>
 <!--        NAVIGATION SECTION
        Contains links to the different sections of the website.
@@ -691,7 +691,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>On Google Classroom, read the <strong>Workshop Safety &amp; Project Brief</strong> document and complete the Safety quiz.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 1 establishes a foundation of safety consciousness and practical awareness of project boundaries. With these principles in mind, you are prepared to begin designing and building your mirror confidently and safely.</p>
 <!-- Additional Resources for Week 1 -->
@@ -804,7 +804,7 @@
 <p><em>Onguard Safety Modules:</em> This week, continue the OnGuard safety tests focusing on hand tools and measuring tools. Ensure you pass the quizzes for tools like the ruler, try square, and marking gauge.</p>
 <h4>Student Activity</h4>
 <p>Draft a final sketch of your mirror frame (attach a photo or scan on Classroom) and complete the <strong>Measuring &amp; Marking Quiz</strong> on Google Classroom.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By combining creative design with precise measuring and marking, you have laid out a roadmap for your project. A well-drawn plan and accurate marks on timber will make the upcoming cutting and joining steps much smoother.</p>
 <!-- Additional Resources for Week 2 -->
@@ -920,7 +920,7 @@
 <p>Taking time to dress your timber correctly pays off later. Straight, square pieces ensure that joints fit tightly and the frame comes out square. It also improves the finish quality; for instance, a planed surface often needs less sanding. Remember, any twist or bow in your pieces now will make joinery difficult later.</p>
 <h4>Student Activity</h4>
 <p>On Classroom, upload a photo of one of your planed boards (showing a smooth surface) and answer the questions in the <strong>Timber Preparation Reflection</strong> form.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By mastering the hand plane and carefully prepping your timber, you’ve taken a big step toward a quality finished project. Well-prepared materials make the upcoming tasks of cutting joints and assembling the frame much easier and more precise.</p>
 <!-- Additional Resources for Week 3 -->
@@ -1033,7 +1033,7 @@
 <p>For more information on wood types and their characteristics, see <a href="https://dragonfiretools.com/blogs/workbench-wisdom-blog/woodworking-101-a-guide-to-choosing-the-right-type-of-wood" style="color: blue;" target="_blank">Woodworking 101: Choosing the Right Type of Wood</a>. It provides examples of common hardwoods and softwoods and their uses.</p>
 <h4>Student Activity</h4>
 <p>Complete the <strong>Joinery Comparison</strong> worksheet on Classroom (list one advantage and one drawback for dowel, biscuit, and domino joints). Also, in the forum, post which joinery method you plan to use for your mirror frame and why.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 4 expands your joinery toolkit and reinforces that choosing the right method and material is key to a strong project. Understanding timber properties helps in selecting good stock for your frame, and knowing multiple joinery options lets you pick what best suits your design and resources. You’re now ready to start creating joints in your mirror frame with confidence.</p>
 <!-- Additional Resources for Week 4 -->
@@ -1151,7 +1151,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>In your workbook (or Classroom assignment), answer the questions in <strong>Mortise &amp; Tenon Part 1</strong>: Describe the steps to cut a mortise, and explain why the mortise is cut before the tenon in fitting this joint.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By the end of Week 5, you should have one or more mortises cut for a sample joint and a solid understanding of how and why mortise dimensions are chosen. Mastery of the mortise forms the foundation; next week, we will tackle crafting the matching tenon and assembling the joint.</p>
 <!-- Additional Resources for Week 5 -->
@@ -1270,7 +1270,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>Complete the <strong>M&amp;T Joint Quiz</strong> on Classroom (covering terminology like “cheeks” and “shoulders” and best practices for fitting). If you made a sample M&amp;T joint, upload a photo and brief note about how it went.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By completing the mortise and tenon joint, you’ve practised one of the most important woodworking joints. Even if your mirror frame won’t explicitly use a hidden M&amp;T, the skills of careful measuring, cutting, and fitting apply to all joinery. Week 6 wraps up our intensive focus on joinery techniques – from here, we’ll start adding creative features and moving toward finishing the project.</p>
 <!-- Additional Resources for Week 6 -->
@@ -1319,7 +1319,7 @@
 <p>If you have chosen to use any different wood for decorative effect (perhaps a strip of a darker hardwood inlay), research that wood’s features so you know how it might behave differently (for example, Tasmanian oak is harder and will need slower cutting, etc.).</p>
 <h4>Student Activity</h4>
 <p>After the router demo, complete the <strong>Router Safety Checklist</strong> quiz on Classroom. For timber types, find one interesting fact about a specific wood species you might like to use in future projects and post it in the discussion (e.g., “Jarrah is termite-resistant” or “Cedar has natural oils that smell pleasant and repel moths”).</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 7 blends practical tool use with deeper material understanding. You’ve gained exposure to the router – an important tool for adding professional touches to your work – and you’ve strengthened your knowledge of timber, the very material we craft. Both aspects will help you make better decisions in the coming stages of building and finishing your mirror frame.</p>
 <!-- Additional Resources for Week 7 -->
@@ -1363,7 +1363,7 @@
 <p>By now, you have encountered various SOPs (for machines like the band saw, disc sander, router, etc.). Ensure that for any task you do this week, you revisit the relevant SOP. For example, if you use the disc sander to slightly adjust a piece, remember to follow the Disc Sander SOP (tie back hair, use the correct side of the disc, etc.). Our goal is to maintain safety standards even as the project work becomes more complex.</p>
 <h4>Student Activity</h4>
 <p>On Classroom, find the <strong>SWMS Template (Frame Assembly)</strong> and fill it out for the mirror frame glue-up process, either individually or with your team. Also, complete the short reflection: “What was one issue you caught during dry fitting that you fixed before gluing?”</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 8 is about foresight and planning – both in assembling your work correctly and in ensuring safety. By dry clamping your project, you ensure a smooth final assembly with no surprises. By writing an SWMS and adhering to SOPs, you cultivate a proactive safety habit that is valuable not just in class but in any workplace or project environment.</p>
 <!-- Additional Resources for Week 8 -->
@@ -1404,7 +1404,7 @@
 </div>
 <h4>Student Activity</h4>
 <p>1) Describe one design feature you plan to add to your mirror (and why) in the Classroom discussion <strong>"My Mirror's Unique Feature"</strong>. 2) Complete the quiz on timber conversion methods – referring to which method yields the most stable boards and which yields the most lumber per log.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 9 balances art and science: you enhance your mirror with creative touches that reflect your personal style, while also learning the scientific/logistical side of how wood gets from forest to workshop. Recognising how timber is converted enriches your appreciation for the material and can influence how you select and use wood in this and future projects.</p>
 <!-- Additional Resources for Week 9 -->
@@ -1442,7 +1442,7 @@
 <p>It’s worth noting: sometimes when projects progress, people get comfortable and might slip on safety habits (e.g., forgetting glasses when sanding). Don’t let that happen. As we gear up for finishing, ensure all safety equipment is ready and commit to safe practices.</p>
 <h4>Student Activity</h4>
 <p>No quiz this week – instead, complete the “Workshop Maintenance Checklist” on Classroom and mark each item as completed. Optionally, share a before-and-after photo of your workbench cleanup.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By finishing all creative woodwork this week, you ensure that the rest of the project can focus on the final finish. A well-organised and maintained workshop sets us up for success in the finishing stage.</p>
 <!-- Additional Resources for Week 10 -->
@@ -1479,7 +1479,7 @@
 <p>For more details, read the article on <a href="https://www.versacetimbers.com.au/advantages-of-timber-seasoning-in-the-building-industry/" style="color: blue;" target="_blank">Versace Timbers: Advantages of Timber Seasoning</a>.</p>
 <h4>Student Activity</h4>
 <p>On Classroom, take the <strong>Timber Seasoning</strong> quiz and update your project log with your observations during glue-up.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By the end of Week 11, your mirror frame is fully glued and taking shape. You now understand why seasoning is critical for long-lasting work. Next, we’ll focus on finishing.</p>
 <!-- Additional Resources for Week 11 -->
@@ -1600,7 +1600,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>Complete the <strong>Sanding 101</strong> assignment on Classroom by listing the grits used and uploading a close-up photo of a finished section.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>With Week 12 complete, your mirror frame is sanded and ready for finishing. You now understand how raw wood is transformed in the workshop.</p>
 <!-- Additional Resources for Week 12 -->
@@ -1659,7 +1659,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>On Classroom, complete the <strong>Finish Plan</strong> assignment by writing which finish you plan to use and why, plus one idea for making your finishing process safer and more eco-friendly.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 13 prepares you to apply finishes with skill and sustainability in mind. You’ll soon see your mirror frame come to life with a beautiful finish.</p>
 <!-- Additional Resources for Week 13 -->
@@ -1700,7 +1700,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>After fitting your mirror, take a photo of the completed piece (front view) and upload it to the <strong>Project Showcase</strong> on Classroom. Then, describe one interesting aspect of the industry visit or video.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 14 is a major milestone as your mirror becomes functional and you gain insights into industry practices, linking your classroom learning with real-world applications.</p>
 <!-- Additional Resources for Week 14 -->
@@ -1744,7 +1744,7 @@
 <p>For example, an MSDS for an oil-based polyurethane will warn about flammability and advise wearing gloves and eye protection.</p>
 <h4>Student Activity</h4>
 <p>This week, find and interpret a real MSDS. Use the provided worksheet on Classroom to answer questions about recommended PPE, storage, and first aid measures.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Understanding MSDS information is crucial for safely handling chemicals in the workshop. This knowledge is essential whether you pursue woodworking as a hobby or a career.</p>
 <!-- Additional Resources for Week 15 -->
@@ -1788,7 +1788,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>On Classroom, complete the <strong>Sustainability Reflection</strong> assignment by writing about one sustainable practice you applied or learned and one idea for future improvements.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 16 reinforces responsible craftsmanship through proper finishing and sustainable practices, ensuring your mirror project is both beautiful and eco-friendly.</p>
 <!-- Additional Resources for Week 16 -->
@@ -1898,7 +1898,7 @@
 <p>Evaluate your work by assessing quality, aesthetics, functionality, and process management. Use both self-assessment and peer feedback to identify strengths and areas for improvement.</p>
 <h4>Student Activity</h4>
 <p>Complete the <strong>Project Evaluation</strong> form on Classroom, and upload your final portfolio file (or submit a physical copy) as required.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 17 is about reflection and communication. Evaluating and presenting your project helps consolidate your learning and builds confidence in your skills.</p>
 <!-- Additional Resources for Week 17 -->
@@ -2008,7 +2008,7 @@
 <p>Your project portfolios and evaluations will be returned with feedback. Use this constructive criticism to improve your future work.</p>
 <h4>Student Activity</h4>
 <p>Complete the class test and then write a short reflection on one aspect you’re proud of and one area for future improvement.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 18 solidifies your understanding through assessment and feedback. It’s a springboard for further learning in your future technical endeavours.</p>
 <!-- Additional Resources for Week 18 -->
@@ -2122,7 +2122,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>Your activity this week is hands-on: complete your assigned cleaning checklist and work as a team to leave the workshop spotless.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 19 reinforces the importance of a clean, organized workspace in a professional setting. Your efforts in cleaning now will benefit everyone in future projects.</p>
 <!-- Additional Resources for Week 19 -->
@@ -3023,7 +3023,7 @@
     <button class="close-popup" aria-label="Close">&times;</button>
     <h3>Results Submitted</h3>
     <p>You can now visit Google Classroom to record your work.</p>
-    <a id="popupClassroomLink" href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" target="_blank">Open Google Classroom</a>
+    <a id="popupClassroomLink" href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" target="_blank">Open Google Classroom</a>
   </div>
 </div>
 <div id="submittedPopup" class="popup-overlay" role="dialog" aria-modal="true">

--- a/Yr-10-Mirror-main/script.js
+++ b/Yr-10-Mirror-main/script.js
@@ -1,5 +1,5 @@
 const SCRIPT_URL = "https://script.google.com/macros/s/AKfycbw1EWli5lAQsObQA47T-OpwAjkXAFSgLcqqf7nCN5zjoEoNMPuA4FmsGSHHN9tKhJhj-w/exec";
-const CLASSROOM_LINK = "https://classroom.google.com/c/NzQ5MDQxMzk4MjAz";
+const CLASSROOM_LINK = "https://classroom.google.com/c/NzkzNDk4NzYwODgw";
 
 const synth = window.speechSynthesis;
 let voices = [];

--- a/Yr-10-Mirror-main/weeks/advanced/week01.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week01.html
@@ -38,7 +38,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>On Google Classroom, read the <strong>Workshop Safety &amp; Project Brief</strong> document and complete the Safety quiz.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 1 establishes a foundation of safety consciousness and practical awareness of project boundaries. With these principles in mind, you are prepared to begin designing and building your mirror confidently and safely.</p>
 <!-- Additional Resources for Week 1 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week02.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week02.html
@@ -37,7 +37,7 @@
 <p><em>Onguard Safety Modules:</em> This week, continue the OnGuard safety tests focusing on hand tools and measuring tools. Ensure you pass the quizzes for tools like the ruler, try square, and marking gauge.</p>
 <h4>Student Activity</h4>
 <p>Draft a final sketch of your mirror frame (attach a photo or scan on Classroom) and complete the <strong>Measuring &amp; Marking Quiz</strong> on Google Classroom.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By combining creative design with precise measuring and marking, you have laid out a roadmap for your project. A well-drawn plan and accurate marks on timber will make the upcoming cutting and joining steps much smoother.</p>
 <!-- Additional Resources for Week 2 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week03.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week03.html
@@ -41,7 +41,7 @@
 <p>Taking time to dress your timber correctly pays off later. Straight, square pieces ensure that joints fit tightly and the frame comes out square. It also improves the finish quality; for instance, a planed surface often needs less sanding. Remember, any twist or bow in your pieces now will make joinery difficult later.</p>
 <h4>Student Activity</h4>
 <p>On Classroom, upload a photo of one of your planed boards (showing a smooth surface) and answer the questions in the <strong>Timber Preparation Reflection</strong> form.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By mastering the hand plane and carefully prepping your timber, you’ve taken a big step toward a quality finished project. Well-prepared materials make the upcoming tasks of cutting joints and assembling the frame much easier and more precise.</p>
 <!-- Additional Resources for Week 3 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week04.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week04.html
@@ -43,7 +43,7 @@
 <p>For more information on wood types and their characteristics, see <a href="https://dragonfiretools.com/blogs/workbench-wisdom-blog/woodworking-101-a-guide-to-choosing-the-right-type-of-wood" style="color: blue;" target="_blank">Woodworking 101: Choosing the Right Type of Wood</a>. It provides examples of common hardwoods and softwoods and their uses.</p>
 <h4>Student Activity</h4>
 <p>Complete the <strong>Joinery Comparison</strong> worksheet on Classroom (list one advantage and one drawback for dowel, biscuit, and domino joints). Also, in the forum, post which joinery method you plan to use for your mirror frame and why.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 4 expands your joinery toolkit and reinforces that choosing the right method and material is key to a strong project. Understanding timber properties helps in selecting good stock for your frame, and knowing multiple joinery options lets you pick what best suits your design and resources. You’re now ready to start creating joints in your mirror frame with confidence.</p>
 <!-- Additional Resources for Week 4 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week05.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week05.html
@@ -46,7 +46,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>In your workbook (or Classroom assignment), answer the questions in <strong>Mortise &amp; Tenon Part 1</strong>: Describe the steps to cut a mortise, and explain why the mortise is cut before the tenon in fitting this joint.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By the end of Week 5, you should have one or more mortises cut for a sample joint and a solid understanding of how and why mortise dimensions are chosen. Mastery of the mortise forms the foundation; next week, we will tackle crafting the matching tenon and assembling the joint.</p>
 <!-- Additional Resources for Week 5 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week06.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week06.html
@@ -42,7 +42,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>Complete the <strong>M&amp;T Joint Quiz</strong> on Classroom (covering terminology like “cheeks” and “shoulders” and best practices for fitting). If you made a sample M&amp;T joint, upload a photo and brief note about how it went.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By completing the mortise and tenon joint, you’ve practised one of the most important woodworking joints. Even if your mirror frame won’t explicitly use a hidden M&amp;T, the skills of careful measuring, cutting, and fitting apply to all joinery. Week 6 wraps up our intensive focus on joinery techniques – from here, we’ll start adding creative features and moving toward finishing the project.</p>
 <!-- Additional Resources for Week 6 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week07.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week07.html
@@ -50,7 +50,7 @@
 <p>If you have chosen to use any different wood for decorative effect (perhaps a strip of a darker hardwood inlay), research that wood’s features so you know how it might behave differently (for example, Tasmanian oak is harder and will need slower cutting, etc.).</p>
 <h4>Student Activity</h4>
 <p>After the router demo, complete the <strong>Router Safety Checklist</strong> quiz on Classroom. For timber types, find one interesting fact about a specific wood species you might like to use in future projects and post it in the discussion (e.g., “Jarrah is termite-resistant” or “Cedar has natural oils that smell pleasant and repel moths”).</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 7 blends practical tool use with deeper material understanding. You’ve gained exposure to the router – an important tool for adding professional touches to your work – and you’ve strengthened your knowledge of timber, the very material we craft. Both aspects will help you make better decisions in the coming stages of building and finishing your mirror frame.</p>
 <!-- Additional Resources for Week 7 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week08.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week08.html
@@ -46,7 +46,7 @@
 <p>By now, you have encountered various SOPs (for machines like the band saw, disc sander, router, etc.). Ensure that for any task you do this week, you revisit the relevant SOP. For example, if you use the disc sander to slightly adjust a piece, remember to follow the Disc Sander SOP (tie back hair, use the correct side of the disc, etc.). Our goal is to maintain safety standards even as the project work becomes more complex.</p>
 <h4>Student Activity</h4>
 <p>On Classroom, find the <strong>SWMS Template (Frame Assembly)</strong> and fill it out for the mirror frame glue-up process, either individually or with your team. Also, complete the short reflection: “What was one issue you caught during dry fitting that you fixed before gluing?”</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 8 is about foresight and planning – both in assembling your work correctly and in ensuring safety. By dry clamping your project, you ensure a smooth final assembly with no surprises. By writing an SWMS and adhering to SOPs, you cultivate a proactive safety habit that is valuable not just in class but in any workplace or project environment.</p>
 <!-- Additional Resources for Week 8 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week09.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week09.html
@@ -42,7 +42,7 @@
 </div>
 <h4>Student Activity</h4>
 <p>1) Describe one design feature you plan to add to your mirror (and why) in the Classroom discussion <strong>"My Mirror's Unique Feature"</strong>. 2) Complete the quiz on timber conversion methods – referring to which method yields the most stable boards and which yields the most lumber per log.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 9 balances art and science: you enhance your mirror with creative touches that reflect your personal style, while also learning the scientific/logistical side of how wood gets from forest to workshop. Recognising how timber is converted enriches your appreciation for the material and can influence how you select and use wood in this and future projects.</p>
 <!-- Additional Resources for Week 9 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week10.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week10.html
@@ -39,7 +39,7 @@
 <p>It’s worth noting: sometimes when projects progress, people get comfortable and might slip on safety habits (e.g., forgetting glasses when sanding). Don’t let that happen. As we gear up for finishing, ensure all safety equipment is ready and commit to safe practices.</p>
 <h4>Student Activity</h4>
 <p>No quiz this week – instead, complete the “Workshop Maintenance Checklist” on Classroom and mark each item as completed. Optionally, share a before-and-after photo of your workbench cleanup.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By finishing all creative woodwork this week, you ensure that the rest of the project can focus on the final finish. A well-organised and maintained workshop sets us up for success in the finishing stage.</p>
 <!-- Additional Resources for Week 10 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week11.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week11.html
@@ -38,7 +38,7 @@
 <p>For more details, read the article on <a href="https://www.versacetimbers.com.au/advantages-of-timber-seasoning-in-the-building-industry/" style="color: blue;" target="_blank">Versace Timbers: Advantages of Timber Seasoning</a>.</p>
 <h4>Student Activity</h4>
 <p>On Classroom, take the <strong>Timber Seasoning</strong> quiz and update your project log with your observations during glue-up.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By the end of Week 11, your mirror frame is fully glued and taking shape. You now understand why seasoning is critical for long-lasting work. Next, we’ll focus on finishing.</p>
 <!-- Additional Resources for Week 11 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week12.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week12.html
@@ -42,7 +42,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>Complete the <strong>Sanding 101</strong> assignment on Classroom by listing the grits used and uploading a close-up photo of a finished section.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>With Week 12 complete, your mirror frame is sanded and ready for finishing. You now understand how raw wood is transformed in the workshop.</p>
 <!-- Additional Resources for Week 12 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week13.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week13.html
@@ -51,7 +51,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>On Classroom, complete the <strong>Finish Plan</strong> assignment by writing which finish you plan to use and why, plus one idea for making your finishing process safer and more eco-friendly.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 13 prepares you to apply finishes with skill and sustainability in mind. You’ll soon see your mirror frame come to life with a beautiful finish.</p>
 <!-- Additional Resources for Week 13 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week14.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week14.html
@@ -34,7 +34,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>After fitting your mirror, take a photo of the completed piece (front view) and upload it to the <strong>Project Showcase</strong> on Classroom. Then, describe one interesting aspect of the industry visit or video.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 14 is a major milestone as your mirror becomes functional and you gain insights into industry practices, linking your classroom learning with real-world applications.</p>
 <!-- Additional Resources for Week 14 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week15.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week15.html
@@ -36,7 +36,7 @@
 <p>For example, an MSDS for an oil-based polyurethane will warn about flammability and advise wearing gloves and eye protection.</p>
 <h4>Student Activity</h4>
 <p>This week, find and interpret a real MSDS. Use the provided worksheet on Classroom to answer questions about recommended PPE, storage, and first aid measures.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Understanding MSDS information is crucial for safely handling chemicals in the workshop. This knowledge is essential whether you pursue woodworking as a hobby or a career.</p>
 <!-- Additional Resources for Week 15 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week16.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week16.html
@@ -36,7 +36,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>On Classroom, complete the <strong>Sustainability Reflection</strong> assignment by writing about one sustainable practice you applied or learned and one idea for future improvements.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 16 reinforces responsible craftsmanship through proper finishing and sustainable practices, ensuring your mirror project is both beautiful and eco-friendly.</p>
 <!-- Additional Resources for Week 16 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week17.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week17.html
@@ -33,7 +33,7 @@
 <p>Evaluate your work by assessing quality, aesthetics, functionality, and process management. Use both self-assessment and peer feedback to identify strengths and areas for improvement.</p>
 <h4>Student Activity</h4>
 <p>Complete the <strong>Project Evaluation</strong> form on Classroom, and upload your final portfolio file (or submit a physical copy) as required.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 17 is about reflection and communication. Evaluating and presenting your project helps consolidate your learning and builds confidence in your skills.</p>
 <!-- Additional Resources for Week 17 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week18.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week18.html
@@ -33,7 +33,7 @@
 <p>Your project portfolios and evaluations will be returned with feedback. Use this constructive criticism to improve your future work.</p>
 <h4>Student Activity</h4>
 <p>Complete the class test and then write a short reflection on one aspect you’re proud of and one area for future improvement.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 18 solidifies your understanding through assessment and feedback. It’s a springboard for further learning in your future technical endeavours.</p>
 <!-- Additional Resources for Week 18 -->

--- a/Yr-10-Mirror-main/weeks/advanced/week19.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week19.html
@@ -37,7 +37,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>Your activity this week is hands-on: complete your assigned cleaning checklist and work as a team to leave the workshop spotless.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 19 reinforces the importance of a clean, organized workspace in a professional setting. Your efforts in cleaning now will benefit everyone in future projects.</p>
 <!-- Additional Resources for Week 19 -->

--- a/Yr-10-Mirror-main/weeks/main/week01.html
+++ b/Yr-10-Mirror-main/weeks/main/week01.html
@@ -38,7 +38,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>On Google Classroom, read the <strong>Workshop Safety &amp; Project Brief</strong> document and complete the Safety quiz.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 1 establishes a foundation of safety consciousness and practical awareness of project boundaries. With these principles in mind, you are prepared to begin designing and building your mirror confidently and safely.</p>
 <!-- Additional Resources for Week 1 -->

--- a/Yr-10-Mirror-main/weeks/main/week02.html
+++ b/Yr-10-Mirror-main/weeks/main/week02.html
@@ -37,7 +37,7 @@
 <p><em>Onguard Safety Modules:</em> This week, continue the OnGuard safety tests focusing on hand tools and measuring tools. Ensure you pass the quizzes for tools like the ruler, try square, and marking gauge.</p>
 <h4>Student Activity</h4>
 <p>Draft a final sketch of your mirror frame (attach a photo or scan on Classroom) and complete the <strong>Measuring &amp; Marking Quiz</strong> on Google Classroom.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By combining creative design with precise measuring and marking, you have laid out a roadmap for your project. A well-drawn plan and accurate marks on timber will make the upcoming cutting and joining steps much smoother.</p>
 <!-- Additional Resources for Week 2 -->

--- a/Yr-10-Mirror-main/weeks/main/week03.html
+++ b/Yr-10-Mirror-main/weeks/main/week03.html
@@ -41,7 +41,7 @@
 <p>Taking time to dress your timber correctly pays off later. Straight, square pieces ensure that joints fit tightly and the frame comes out square. It also improves the finish quality; for instance, a planed surface often needs less sanding. Remember, any twist or bow in your pieces now will make joinery difficult later.</p>
 <h4>Student Activity</h4>
 <p>On Classroom, upload a photo of one of your planed boards (showing a smooth surface) and answer the questions in the <strong>Timber Preparation Reflection</strong> form.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By mastering the hand plane and carefully prepping your timber, you’ve taken a big step toward a quality finished project. Well-prepared materials make the upcoming tasks of cutting joints and assembling the frame much easier and more precise.</p>
 <!-- Additional Resources for Week 3 -->

--- a/Yr-10-Mirror-main/weeks/main/week04.html
+++ b/Yr-10-Mirror-main/weeks/main/week04.html
@@ -43,7 +43,7 @@
 <p>For more information on wood types and their characteristics, see <a href="https://dragonfiretools.com/blogs/workbench-wisdom-blog/woodworking-101-a-guide-to-choosing-the-right-type-of-wood" style="color: blue;" target="_blank">Woodworking 101: Choosing the Right Type of Wood</a>. It provides examples of common hardwoods and softwoods and their uses.</p>
 <h4>Student Activity</h4>
 <p>Complete the <strong>Joinery Comparison</strong> worksheet on Classroom (list one advantage and one drawback for dowel, biscuit, and domino joints). Also, in the forum, post which joinery method you plan to use for your mirror frame and why.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 4 expands your joinery toolkit and reinforces that choosing the right method and material is key to a strong project. Understanding timber properties helps in selecting good stock for your frame, and knowing multiple joinery options lets you pick what best suits your design and resources. You’re now ready to start creating joints in your mirror frame with confidence.</p>
 <!-- Additional Resources for Week 4 -->

--- a/Yr-10-Mirror-main/weeks/main/week05.html
+++ b/Yr-10-Mirror-main/weeks/main/week05.html
@@ -46,7 +46,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>In your workbook (or Classroom assignment), answer the questions in <strong>Mortise &amp; Tenon Part 1</strong>: Describe the steps to cut a mortise, and explain why the mortise is cut before the tenon in fitting this joint.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By the end of Week 5, you should have one or more mortises cut for a sample joint and a solid understanding of how and why mortise dimensions are chosen. Mastery of the mortise forms the foundation; next week, we will tackle crafting the matching tenon and assembling the joint.</p>
 <!-- Additional Resources for Week 5 -->

--- a/Yr-10-Mirror-main/weeks/main/week06.html
+++ b/Yr-10-Mirror-main/weeks/main/week06.html
@@ -42,7 +42,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>Complete the <strong>M&amp;T Joint Quiz</strong> on Classroom (covering terminology like “cheeks” and “shoulders” and best practices for fitting). If you made a sample M&amp;T joint, upload a photo and brief note about how it went.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By completing the mortise and tenon joint, you’ve practised one of the most important woodworking joints. Even if your mirror frame won’t explicitly use a hidden M&amp;T, the skills of careful measuring, cutting, and fitting apply to all joinery. Week 6 wraps up our intensive focus on joinery techniques – from here, we’ll start adding creative features and moving toward finishing the project.</p>
 <!-- Additional Resources for Week 6 -->

--- a/Yr-10-Mirror-main/weeks/main/week07.html
+++ b/Yr-10-Mirror-main/weeks/main/week07.html
@@ -50,7 +50,7 @@
 <p>If you have chosen to use any different wood for decorative effect (perhaps a strip of a darker hardwood inlay), research that wood’s features so you know how it might behave differently (for example, Tasmanian oak is harder and will need slower cutting, etc.).</p>
 <h4>Student Activity</h4>
 <p>After the router demo, complete the <strong>Router Safety Checklist</strong> quiz on Classroom. For timber types, find one interesting fact about a specific wood species you might like to use in future projects and post it in the discussion (e.g., “Jarrah is termite-resistant” or “Cedar has natural oils that smell pleasant and repel moths”).</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 7 blends practical tool use with deeper material understanding. You’ve gained exposure to the router – an important tool for adding professional touches to your work – and you’ve strengthened your knowledge of timber, the very material we craft. Both aspects will help you make better decisions in the coming stages of building and finishing your mirror frame.</p>
 <!-- Additional Resources for Week 7 -->

--- a/Yr-10-Mirror-main/weeks/main/week08.html
+++ b/Yr-10-Mirror-main/weeks/main/week08.html
@@ -46,7 +46,7 @@
 <p>By now, you have encountered various SOPs (for machines like the band saw, disc sander, router, etc.). Ensure that for any task you do this week, you revisit the relevant SOP. For example, if you use the disc sander to slightly adjust a piece, remember to follow the Disc Sander SOP (tie back hair, use the correct side of the disc, etc.). Our goal is to maintain safety standards even as the project work becomes more complex.</p>
 <h4>Student Activity</h4>
 <p>On Classroom, find the <strong>SWMS Template (Frame Assembly)</strong> and fill it out for the mirror frame glue-up process, either individually or with your team. Also, complete the short reflection: “What was one issue you caught during dry fitting that you fixed before gluing?”</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 8 is about foresight and planning – both in assembling your work correctly and in ensuring safety. By dry clamping your project, you ensure a smooth final assembly with no surprises. By writing an SWMS and adhering to SOPs, you cultivate a proactive safety habit that is valuable not just in class but in any workplace or project environment.</p>
 <!-- Additional Resources for Week 8 -->

--- a/Yr-10-Mirror-main/weeks/main/week09.html
+++ b/Yr-10-Mirror-main/weeks/main/week09.html
@@ -42,7 +42,7 @@
 </div>
 <h4>Student Activity</h4>
 <p>1) Describe one design feature you plan to add to your mirror (and why) in the Classroom discussion <strong>"My Mirror's Unique Feature"</strong>. 2) Complete the quiz on timber conversion methods – referring to which method yields the most stable boards and which yields the most lumber per log.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 9 balances art and science: you enhance your mirror with creative touches that reflect your personal style, while also learning the scientific/logistical side of how wood gets from forest to workshop. Recognising how timber is converted enriches your appreciation for the material and can influence how you select and use wood in this and future projects.</p>
 <!-- Additional Resources for Week 9 -->

--- a/Yr-10-Mirror-main/weeks/main/week10.html
+++ b/Yr-10-Mirror-main/weeks/main/week10.html
@@ -39,7 +39,7 @@
 <p>It’s worth noting: sometimes when projects progress, people get comfortable and might slip on safety habits (e.g., forgetting glasses when sanding). Don’t let that happen. As we gear up for finishing, ensure all safety equipment is ready and commit to safe practices.</p>
 <h4>Student Activity</h4>
 <p>No quiz this week – instead, complete the “Workshop Maintenance Checklist” on Classroom and mark each item as completed. Optionally, share a before-and-after photo of your workbench cleanup.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By finishing all creative woodwork this week, you ensure that the rest of the project can focus on the final finish. A well-organised and maintained workshop sets us up for success in the finishing stage.</p>
 <!-- Additional Resources for Week 10 -->

--- a/Yr-10-Mirror-main/weeks/main/week11.html
+++ b/Yr-10-Mirror-main/weeks/main/week11.html
@@ -38,7 +38,7 @@
 <p>For more details, read the article on <a href="https://www.versacetimbers.com.au/advantages-of-timber-seasoning-in-the-building-industry/" style="color: blue;" target="_blank">Versace Timbers: Advantages of Timber Seasoning</a>.</p>
 <h4>Student Activity</h4>
 <p>On Classroom, take the <strong>Timber Seasoning</strong> quiz and update your project log with your observations during glue-up.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By the end of Week 11, your mirror frame is fully glued and taking shape. You now understand why seasoning is critical for long-lasting work. Next, we’ll focus on finishing.</p>
 <!-- Additional Resources for Week 11 -->

--- a/Yr-10-Mirror-main/weeks/main/week12.html
+++ b/Yr-10-Mirror-main/weeks/main/week12.html
@@ -42,7 +42,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>Complete the <strong>Sanding 101</strong> assignment on Classroom by listing the grits used and uploading a close-up photo of a finished section.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>With Week 12 complete, your mirror frame is sanded and ready for finishing. You now understand how raw wood is transformed in the workshop.</p>
 <!-- Additional Resources for Week 12 -->

--- a/Yr-10-Mirror-main/weeks/main/week13.html
+++ b/Yr-10-Mirror-main/weeks/main/week13.html
@@ -51,7 +51,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>On Classroom, complete the <strong>Finish Plan</strong> assignment by writing which finish you plan to use and why, plus one idea for making your finishing process safer and more eco-friendly.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 13 prepares you to apply finishes with skill and sustainability in mind. You’ll soon see your mirror frame come to life with a beautiful finish.</p>
 <!-- Additional Resources for Week 13 -->

--- a/Yr-10-Mirror-main/weeks/main/week14.html
+++ b/Yr-10-Mirror-main/weeks/main/week14.html
@@ -34,7 +34,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>After fitting your mirror, take a photo of the completed piece (front view) and upload it to the <strong>Project Showcase</strong> on Classroom. Then, describe one interesting aspect of the industry visit or video.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 14 is a major milestone as your mirror becomes functional and you gain insights into industry practices, linking your classroom learning with real-world applications.</p>
 <!-- Additional Resources for Week 14 -->

--- a/Yr-10-Mirror-main/weeks/main/week15.html
+++ b/Yr-10-Mirror-main/weeks/main/week15.html
@@ -36,7 +36,7 @@
 <p>For example, an MSDS for an oil-based polyurethane will warn about flammability and advise wearing gloves and eye protection.</p>
 <h4>Student Activity</h4>
 <p>This week, find and interpret a real MSDS. Use the provided worksheet on Classroom to answer questions about recommended PPE, storage, and first aid measures.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Understanding MSDS information is crucial for safely handling chemicals in the workshop. This knowledge is essential whether you pursue woodworking as a hobby or a career.</p>
 <!-- Additional Resources for Week 15 -->

--- a/Yr-10-Mirror-main/weeks/main/week16.html
+++ b/Yr-10-Mirror-main/weeks/main/week16.html
@@ -36,7 +36,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>On Classroom, complete the <strong>Sustainability Reflection</strong> assignment by writing about one sustainable practice you applied or learned and one idea for future improvements.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 16 reinforces responsible craftsmanship through proper finishing and sustainable practices, ensuring your mirror project is both beautiful and eco-friendly.</p>
 <!-- Additional Resources for Week 16 -->

--- a/Yr-10-Mirror-main/weeks/main/week17.html
+++ b/Yr-10-Mirror-main/weeks/main/week17.html
@@ -33,7 +33,7 @@
 <p>Evaluate your work by assessing quality, aesthetics, functionality, and process management. Use both self-assessment and peer feedback to identify strengths and areas for improvement.</p>
 <h4>Student Activity</h4>
 <p>Complete the <strong>Project Evaluation</strong> form on Classroom, and upload your final portfolio file (or submit a physical copy) as required.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 17 is about reflection and communication. Evaluating and presenting your project helps consolidate your learning and builds confidence in your skills.</p>
 <!-- Additional Resources for Week 17 -->

--- a/Yr-10-Mirror-main/weeks/main/week18.html
+++ b/Yr-10-Mirror-main/weeks/main/week18.html
@@ -33,7 +33,7 @@
 <p>Your project portfolios and evaluations will be returned with feedback. Use this constructive criticism to improve your future work.</p>
 <h4>Student Activity</h4>
 <p>Complete the class test and then write a short reflection on one aspect you’re proud of and one area for future improvement.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 18 solidifies your understanding through assessment and feedback. It’s a springboard for further learning in your future technical endeavours.</p>
 <!-- Additional Resources for Week 18 -->

--- a/Yr-10-Mirror-main/weeks/main/week19.html
+++ b/Yr-10-Mirror-main/weeks/main/week19.html
@@ -37,7 +37,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>Your activity this week is hands-on: complete your assigned cleaning checklist and work as a team to leave the workshop spotless.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 19 reinforces the importance of a clean, organized workspace in a professional setting. Your efforts in cleaning now will benefit everyone in future projects.</p>
 <!-- Additional Resources for Week 19 -->

--- a/Yr-10-Mirror-main/weeks/support/week01.html
+++ b/Yr-10-Mirror-main/weeks/support/week01.html
@@ -38,7 +38,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>On Google Classroom, read the <strong>Workshop Safety &amp; Project Brief</strong> document and complete the Safety quiz.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 1 establishes a foundation of safety consciousness and practical awareness of project boundaries. With these principles in mind, you are prepared to begin designing and building your mirror confidently and safely.</p>
 <!-- Additional Resources for Week 1 -->

--- a/Yr-10-Mirror-main/weeks/support/week02.html
+++ b/Yr-10-Mirror-main/weeks/support/week02.html
@@ -37,7 +37,7 @@
 <p><em>Onguard Safety Modules:</em> This week, continue the OnGuard safety tests focusing on hand tools and measuring tools. Ensure you pass the quizzes for tools like the ruler, try square, and marking gauge.</p>
 <h4>Student Activity</h4>
 <p>Draft a final sketch of your mirror frame (attach a photo or scan on Classroom) and complete the <strong>Measuring &amp; Marking Quiz</strong> on Google Classroom.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By combining creative design with precise measuring and marking, you have laid out a roadmap for your project. A well-drawn plan and accurate marks on timber will make the upcoming cutting and joining steps much smoother.</p>
 <!-- Additional Resources for Week 2 -->

--- a/Yr-10-Mirror-main/weeks/support/week03.html
+++ b/Yr-10-Mirror-main/weeks/support/week03.html
@@ -41,7 +41,7 @@
 <p>Taking time to dress your timber correctly pays off later. Straight, square pieces ensure that joints fit tightly and the frame comes out square. It also improves the finish quality; for instance, a planed surface often needs less sanding. Remember, any twist or bow in your pieces now will make joinery difficult later.</p>
 <h4>Student Activity</h4>
 <p>On Classroom, upload a photo of one of your planed boards (showing a smooth surface) and answer the questions in the <strong>Timber Preparation Reflection</strong> form.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By mastering the hand plane and carefully prepping your timber, you’ve taken a big step toward a quality finished project. Well-prepared materials make the upcoming tasks of cutting joints and assembling the frame much easier and more precise.</p>
 <!-- Additional Resources for Week 3 -->

--- a/Yr-10-Mirror-main/weeks/support/week04.html
+++ b/Yr-10-Mirror-main/weeks/support/week04.html
@@ -43,7 +43,7 @@
 <p>For more information on wood types and their characteristics, see <a href="https://dragonfiretools.com/blogs/workbench-wisdom-blog/woodworking-101-a-guide-to-choosing-the-right-type-of-wood" style="color: blue;" target="_blank">Woodworking 101: Choosing the Right Type of Wood</a>. It provides examples of common hardwoods and softwoods and their uses.</p>
 <h4>Student Activity</h4>
 <p>Complete the <strong>Joinery Comparison</strong> worksheet on Classroom (list one advantage and one drawback for dowel, biscuit, and domino joints). Also, in the forum, post which joinery method you plan to use for your mirror frame and why.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 4 expands your joinery toolkit and reinforces that choosing the right method and material is key to a strong project. Understanding timber properties helps in selecting good stock for your frame, and knowing multiple joinery options lets you pick what best suits your design and resources. You’re now ready to start creating joints in your mirror frame with confidence.</p>
 <!-- Additional Resources for Week 4 -->

--- a/Yr-10-Mirror-main/weeks/support/week05.html
+++ b/Yr-10-Mirror-main/weeks/support/week05.html
@@ -46,7 +46,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>In your workbook (or Classroom assignment), answer the questions in <strong>Mortise &amp; Tenon Part 1</strong>: Describe the steps to cut a mortise, and explain why the mortise is cut before the tenon in fitting this joint.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By the end of Week 5, you should have one or more mortises cut for a sample joint and a solid understanding of how and why mortise dimensions are chosen. Mastery of the mortise forms the foundation; next week, we will tackle crafting the matching tenon and assembling the joint.</p>
 <!-- Additional Resources for Week 5 -->

--- a/Yr-10-Mirror-main/weeks/support/week06.html
+++ b/Yr-10-Mirror-main/weeks/support/week06.html
@@ -42,7 +42,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>Complete the <strong>M&amp;T Joint Quiz</strong> on Classroom (covering terminology like “cheeks” and “shoulders” and best practices for fitting). If you made a sample M&amp;T joint, upload a photo and brief note about how it went.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By completing the mortise and tenon joint, you’ve practised one of the most important woodworking joints. Even if your mirror frame won’t explicitly use a hidden M&amp;T, the skills of careful measuring, cutting, and fitting apply to all joinery. Week 6 wraps up our intensive focus on joinery techniques – from here, we’ll start adding creative features and moving toward finishing the project.</p>
 <!-- Additional Resources for Week 6 -->

--- a/Yr-10-Mirror-main/weeks/support/week07.html
+++ b/Yr-10-Mirror-main/weeks/support/week07.html
@@ -50,7 +50,7 @@
 <p>If you have chosen to use any different wood for decorative effect (perhaps a strip of a darker hardwood inlay), research that wood’s features so you know how it might behave differently (for example, Tasmanian oak is harder and will need slower cutting, etc.).</p>
 <h4>Student Activity</h4>
 <p>After the router demo, complete the <strong>Router Safety Checklist</strong> quiz on Classroom. For timber types, find one interesting fact about a specific wood species you might like to use in future projects and post it in the discussion (e.g., “Jarrah is termite-resistant” or “Cedar has natural oils that smell pleasant and repel moths”).</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 7 blends practical tool use with deeper material understanding. You’ve gained exposure to the router – an important tool for adding professional touches to your work – and you’ve strengthened your knowledge of timber, the very material we craft. Both aspects will help you make better decisions in the coming stages of building and finishing your mirror frame.</p>
 <!-- Additional Resources for Week 7 -->

--- a/Yr-10-Mirror-main/weeks/support/week08.html
+++ b/Yr-10-Mirror-main/weeks/support/week08.html
@@ -46,7 +46,7 @@
 <p>By now, you have encountered various SOPs (for machines like the band saw, disc sander, router, etc.). Ensure that for any task you do this week, you revisit the relevant SOP. For example, if you use the disc sander to slightly adjust a piece, remember to follow the Disc Sander SOP (tie back hair, use the correct side of the disc, etc.). Our goal is to maintain safety standards even as the project work becomes more complex.</p>
 <h4>Student Activity</h4>
 <p>On Classroom, find the <strong>SWMS Template (Frame Assembly)</strong> and fill it out for the mirror frame glue-up process, either individually or with your team. Also, complete the short reflection: “What was one issue you caught during dry fitting that you fixed before gluing?”</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 8 is about foresight and planning – both in assembling your work correctly and in ensuring safety. By dry clamping your project, you ensure a smooth final assembly with no surprises. By writing an SWMS and adhering to SOPs, you cultivate a proactive safety habit that is valuable not just in class but in any workplace or project environment.</p>
 <!-- Additional Resources for Week 8 -->

--- a/Yr-10-Mirror-main/weeks/support/week09.html
+++ b/Yr-10-Mirror-main/weeks/support/week09.html
@@ -42,7 +42,7 @@
 </div>
 <h4>Student Activity</h4>
 <p>1) Describe one design feature you plan to add to your mirror (and why) in the Classroom discussion <strong>"My Mirror's Unique Feature"</strong>. 2) Complete the quiz on timber conversion methods – referring to which method yields the most stable boards and which yields the most lumber per log.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 9 balances art and science: you enhance your mirror with creative touches that reflect your personal style, while also learning the scientific/logistical side of how wood gets from forest to workshop. Recognising how timber is converted enriches your appreciation for the material and can influence how you select and use wood in this and future projects.</p>
 <!-- Additional Resources for Week 9 -->

--- a/Yr-10-Mirror-main/weeks/support/week10.html
+++ b/Yr-10-Mirror-main/weeks/support/week10.html
@@ -39,7 +39,7 @@
 <p>It’s worth noting: sometimes when projects progress, people get comfortable and might slip on safety habits (e.g., forgetting glasses when sanding). Don’t let that happen. As we gear up for finishing, ensure all safety equipment is ready and commit to safe practices.</p>
 <h4>Student Activity</h4>
 <p>No quiz this week – instead, complete the “Workshop Maintenance Checklist” on Classroom and mark each item as completed. Optionally, share a before-and-after photo of your workbench cleanup.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By finishing all creative woodwork this week, you ensure that the rest of the project can focus on the final finish. A well-organised and maintained workshop sets us up for success in the finishing stage.</p>
 <!-- Additional Resources for Week 10 -->

--- a/Yr-10-Mirror-main/weeks/support/week11.html
+++ b/Yr-10-Mirror-main/weeks/support/week11.html
@@ -38,7 +38,7 @@
 <p>For more details, read the article on <a href="https://www.versacetimbers.com.au/advantages-of-timber-seasoning-in-the-building-industry/" style="color: blue;" target="_blank">Versace Timbers: Advantages of Timber Seasoning</a>.</p>
 <h4>Student Activity</h4>
 <p>On Classroom, take the <strong>Timber Seasoning</strong> quiz and update your project log with your observations during glue-up.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>By the end of Week 11, your mirror frame is fully glued and taking shape. You now understand why seasoning is critical for long-lasting work. Next, we’ll focus on finishing.</p>
 <!-- Additional Resources for Week 11 -->

--- a/Yr-10-Mirror-main/weeks/support/week12.html
+++ b/Yr-10-Mirror-main/weeks/support/week12.html
@@ -42,7 +42,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>Complete the <strong>Sanding 101</strong> assignment on Classroom by listing the grits used and uploading a close-up photo of a finished section.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>With Week 12 complete, your mirror frame is sanded and ready for finishing. You now understand how raw wood is transformed in the workshop.</p>
 <!-- Additional Resources for Week 12 -->

--- a/Yr-10-Mirror-main/weeks/support/week13.html
+++ b/Yr-10-Mirror-main/weeks/support/week13.html
@@ -51,7 +51,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>On Classroom, complete the <strong>Finish Plan</strong> assignment by writing which finish you plan to use and why, plus one idea for making your finishing process safer and more eco-friendly.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 13 prepares you to apply finishes with skill and sustainability in mind. You’ll soon see your mirror frame come to life with a beautiful finish.</p>
 <!-- Additional Resources for Week 13 -->

--- a/Yr-10-Mirror-main/weeks/support/week14.html
+++ b/Yr-10-Mirror-main/weeks/support/week14.html
@@ -34,7 +34,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>After fitting your mirror, take a photo of the completed piece (front view) and upload it to the <strong>Project Showcase</strong> on Classroom. Then, describe one interesting aspect of the industry visit or video.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 14 is a major milestone as your mirror becomes functional and you gain insights into industry practices, linking your classroom learning with real-world applications.</p>
 <!-- Additional Resources for Week 14 -->

--- a/Yr-10-Mirror-main/weeks/support/week15.html
+++ b/Yr-10-Mirror-main/weeks/support/week15.html
@@ -36,7 +36,7 @@
 <p>For example, an MSDS for an oil-based polyurethane will warn about flammability and advise wearing gloves and eye protection.</p>
 <h4>Student Activity</h4>
 <p>This week, find and interpret a real MSDS. Use the provided worksheet on Classroom to answer questions about recommended PPE, storage, and first aid measures.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Understanding MSDS information is crucial for safely handling chemicals in the workshop. This knowledge is essential whether you pursue woodworking as a hobby or a career.</p>
 <!-- Additional Resources for Week 15 -->

--- a/Yr-10-Mirror-main/weeks/support/week16.html
+++ b/Yr-10-Mirror-main/weeks/support/week16.html
@@ -36,7 +36,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>On Classroom, complete the <strong>Sustainability Reflection</strong> assignment by writing about one sustainable practice you applied or learned and one idea for future improvements.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 16 reinforces responsible craftsmanship through proper finishing and sustainable practices, ensuring your mirror project is both beautiful and eco-friendly.</p>
 <!-- Additional Resources for Week 16 -->

--- a/Yr-10-Mirror-main/weeks/support/week17.html
+++ b/Yr-10-Mirror-main/weeks/support/week17.html
@@ -33,7 +33,7 @@
 <p>Evaluate your work by assessing quality, aesthetics, functionality, and process management. Use both self-assessment and peer feedback to identify strengths and areas for improvement.</p>
 <h4>Student Activity</h4>
 <p>Complete the <strong>Project Evaluation</strong> form on Classroom, and upload your final portfolio file (or submit a physical copy) as required.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 17 is about reflection and communication. Evaluating and presenting your project helps consolidate your learning and builds confidence in your skills.</p>
 <!-- Additional Resources for Week 17 -->

--- a/Yr-10-Mirror-main/weeks/support/week18.html
+++ b/Yr-10-Mirror-main/weeks/support/week18.html
@@ -33,7 +33,7 @@
 <p>Your project portfolios and evaluations will be returned with feedback. Use this constructive criticism to improve your future work.</p>
 <h4>Student Activity</h4>
 <p>Complete the class test and then write a short reflection on one aspect you’re proud of and one area for future improvement.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 18 solidifies your understanding through assessment and feedback. It’s a springboard for further learning in your future technical endeavours.</p>
 <!-- Additional Resources for Week 18 -->

--- a/Yr-10-Mirror-main/weeks/support/week19.html
+++ b/Yr-10-Mirror-main/weeks/support/week19.html
@@ -37,7 +37,7 @@
 </ul>
 <h4>Student Activity</h4>
 <p>Your activity this week is hands-on: complete your assigned cleaning checklist and work as a team to leave the workshop spotless.</p>
-<p><a href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
+<p><a href="https://classroom.google.com/c/NzkzNDk4NzYwODgw" style="color: blue;" target="_blank">Go to Google Classroom</a></p>
 <h4>Conclusion</h4>
 <p>Week 19 reinforces the importance of a clean, organized workspace in a professional setting. Your efforts in cleaning now will benefit everyone in future projects.</p>
 <!-- Additional Resources for Week 19 -->


### PR DESCRIPTION
### Motivation
- Replace the old Google Classroom invitation link and the displayed join code on the site so students are directed to the new class and can join with the updated code.

### Description
- Updated the Classroom link from `https://classroom.google.com/c/NzQ5MDQxMzk4MjAz` to `https://classroom.google.com/c/NzkzNDk4NzYwODgw` across the homepage, `script.js`, and all weekly pages in `weeks/main/`, `weeks/support/`, and `weeks/advanced/` (many files changed).
- Replaced the classroom join code on the homepage from `l3uugkr` to `i44pfqp6` in `index.html`.
- Updated the popup link (`#popupClassroomLink`) and any other script references that used the old Classroom URL (notably `script.js`).
- Staged and committed the updates (bulk edits across the site; total ~59 files changed).

### Testing
- Verified replacements with `rg` searches to confirm the new Classroom URL appears and the old ID no longer exists, which succeeded.
- Launched a local server with `python -m http.server 8000` and captured a full-page screenshot using Playwright to visually confirm the updated Classroom section, which succeeded and produced `artifacts/google-classroom-update.png`.
- Ran `git status`/`git add`/`git commit` to record the changes, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c2e47db4483268620cbff55a77117)