### PR TITLE
Remove ' - 2025' suffix from main headings

### DIFF
--- a/Yr-10-Mirror-main/index.html
+++ b/Yr-10-Mirror-main/index.html
@@ -16,7 +16,7 @@
        Contains the website title and tagline.
   ============================================================ -->
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Resources, Projects, and Content for Learning</p>
 </header>
 <!--        GOOGLE CLASSROOM SECTION

--- a/Yr-10-Mirror-main/weeks/advanced/week01.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week01.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 1</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week02.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week02.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 2</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week03.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week03.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 3</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week04.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week04.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 4</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week05.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week05.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 5</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week06.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week06.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 6</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week07.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week07.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 7</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week08.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week08.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 8</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week09.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week09.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 9</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week10.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week10.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 10</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week11.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week11.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 11</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week12.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week12.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 12</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week13.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week13.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 13</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week14.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week14.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 14</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week15.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week15.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 15</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week16.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week16.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 16</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week17.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week17.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 17</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week18.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week18.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 18</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week19.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week19.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 19</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/advanced/week20.html
+++ b/Yr-10-Mirror-main/weeks/advanced/week20.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Advanced Content - Week 20</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week01.html
+++ b/Yr-10-Mirror-main/weeks/main/week01.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 1</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week02.html
+++ b/Yr-10-Mirror-main/weeks/main/week02.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 2</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week03.html
+++ b/Yr-10-Mirror-main/weeks/main/week03.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 3</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week04.html
+++ b/Yr-10-Mirror-main/weeks/main/week04.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 4</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week05.html
+++ b/Yr-10-Mirror-main/weeks/main/week05.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 5</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week06.html
+++ b/Yr-10-Mirror-main/weeks/main/week06.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 6</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week07.html
+++ b/Yr-10-Mirror-main/weeks/main/week07.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 7</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week08.html
+++ b/Yr-10-Mirror-main/weeks/main/week08.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 8</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week09.html
+++ b/Yr-10-Mirror-main/weeks/main/week09.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 9</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week10.html
+++ b/Yr-10-Mirror-main/weeks/main/week10.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 10</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week11.html
+++ b/Yr-10-Mirror-main/weeks/main/week11.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 11</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week12.html
+++ b/Yr-10-Mirror-main/weeks/main/week12.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 12</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week13.html
+++ b/Yr-10-Mirror-main/weeks/main/week13.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 13</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week14.html
+++ b/Yr-10-Mirror-main/weeks/main/week14.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 14</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week15.html
+++ b/Yr-10-Mirror-main/weeks/main/week15.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 15</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week16.html
+++ b/Yr-10-Mirror-main/weeks/main/week16.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 16</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week17.html
+++ b/Yr-10-Mirror-main/weeks/main/week17.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 17</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week18.html
+++ b/Yr-10-Mirror-main/weeks/main/week18.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 18</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week19.html
+++ b/Yr-10-Mirror-main/weeks/main/week19.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 19</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/main/week20.html
+++ b/Yr-10-Mirror-main/weeks/main/week20.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Mirror Theory - Week 20</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week01.html
+++ b/Yr-10-Mirror-main/weeks/support/week01.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 1</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week02.html
+++ b/Yr-10-Mirror-main/weeks/support/week02.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 2</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week03.html
+++ b/Yr-10-Mirror-main/weeks/support/week03.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 3</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week04.html
+++ b/Yr-10-Mirror-main/weeks/support/week04.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 4</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week05.html
+++ b/Yr-10-Mirror-main/weeks/support/week05.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 5</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week06.html
+++ b/Yr-10-Mirror-main/weeks/support/week06.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 6</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week07.html
+++ b/Yr-10-Mirror-main/weeks/support/week07.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 7</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week08.html
+++ b/Yr-10-Mirror-main/weeks/support/week08.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 8</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week09.html
+++ b/Yr-10-Mirror-main/weeks/support/week09.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 9</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week10.html
+++ b/Yr-10-Mirror-main/weeks/support/week10.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 10</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week11.html
+++ b/Yr-10-Mirror-main/weeks/support/week11.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 11</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week12.html
+++ b/Yr-10-Mirror-main/weeks/support/week12.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 12</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week13.html
+++ b/Yr-10-Mirror-main/weeks/support/week13.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 13</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week14.html
+++ b/Yr-10-Mirror-main/weeks/support/week14.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 14</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week15.html
+++ b/Yr-10-Mirror-main/weeks/support/week15.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 15</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week16.html
+++ b/Yr-10-Mirror-main/weeks/support/week16.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 16</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week17.html
+++ b/Yr-10-Mirror-main/weeks/support/week17.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 17</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week18.html
+++ b/Yr-10-Mirror-main/weeks/support/week18.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 18</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week19.html
+++ b/Yr-10-Mirror-main/weeks/support/week19.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 19</p>
 </header>
 <main class="content">

--- a/Yr-10-Mirror-main/weeks/support/week20.html
+++ b/Yr-10-Mirror-main/weeks/support/week20.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <header>
-<h1>Year 10 Industrial Technology Timber - 2025</h1>
+<h1>Year 10 Industrial Technology Timber</h1>
 <p>Support Material - Week 20</p>
 </header>
 <main class="content">


### PR DESCRIPTION
### Motivation
- Remove the hard-coded year from the site title headings so the main heading is year-agnostic across the site.

### Description
- Replaced `Year 10 Industrial Technology Timber - 2025` with `Year 10 Industrial Technology Timber` in the homepage and all weekly pages under `weeks/main`, `weeks/support`, and `weeks/advanced`.
- Updated ~61 HTML files' header `<h1>` text to remove the `- 2025` suffix.
- Left unrelated occurrences (for example the `© 2025` in `index.html`) unchanged.

### Testing
- Used `rg` to locate occurrences before and after the change and confirmed heading matches were removed as expected.
- Ran a bulk `sed` replacement to apply the changes and re-checked with `rg -n` to verify the results succeeded.
- Launched a local server with `python -m http.server` and captured a visual check with a Playwright script, producing `artifacts/heading-update.png`, confirming the visible heading was updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69812355f1748326b746502f7d333033)